### PR TITLE
Fix gad-7 test expectation drift (8 sections, 7 scored + Q8 impairment)

### DIFF
--- a/src/__tests__/calculators/gad-7.test.ts
+++ b/src/__tests__/calculators/gad-7.test.ts
@@ -9,7 +9,21 @@ import { calculateScoringResult } from '../../test-utils/scoring-test-utils.js';
 describe('GAD-7 Calculator', () => {
     test('Config Structure', () => {
         expect(gad7Config.id).toBe('gad-7');
-        expect(gad7Config.sections).toHaveLength(7); // 7 questions
+        // GAD-7 standard instrument: 7 scored anxiety items + 1 optional
+        // functional impairment item (Q8). Q8's option values are all 0 so
+        // it never contributes to the score; it is reported separately.
+        expect(gad7Config.sections).toHaveLength(8);
+
+        const scoredSections = gad7Config.sections!.filter(s =>
+            s.options.some(o => Number(o.value) > 0)
+        );
+        expect(scoredSections).toHaveLength(7);
+
+        const unscoredSections = gad7Config.sections!.filter(s =>
+            s.options.every(o => Number(o.value) === 0)
+        );
+        expect(unscoredSections).toHaveLength(1);
+        expect(unscoredSections[0].id).toBe('gad7-q7');
     });
 
     // Scenario 1: Minimal Anxiety (0-4)


### PR DESCRIPTION
## 變更說明

Refs #40。第一個測試 triage PR — 修 gad-7 的 Config Structure assertion 跟上實作（GAD-7 標準工具含 7 scored + 1 unscored functional impairment Q8）。

**Stacked on top of PR #37** — 待 PR #37 merge 後 base 會自動更新為 main，此 PR 即可 merge。

## Intended Use 影響評估

- [ ] **是** — 此變更影響預期用途、臨床判讀邏輯或結果呈現
- [x] **否** — 不影響預期用途（純內部重構、文件、CI、樣式等）

**說明：**
單純測試 assertion 更新 — 從 `toHaveLength(7)` 改為 `toHaveLength(8)` 並補上「7 scored + 1 unscored」的結構性驗證。實作沒動，臨床評分邏輯沒動，UI 沒動。

## 影響範圍

- [ ] 計算器邏輯
- [ ] 使用者介面
- [ ] FHIR 資料整合
- [ ] 安全性相關
- [ ] 基礎架構/CI
- [x] 文件/測試

**受影響的 Calculator IDs：**
- gad-7 (測試 assertion 更新，calculator 實作未動)

**影響的其他模組/檔案：**
- `src/__tests__/calculators/gad-7.test.ts` — Config Structure 測試擴充

## 測試紀錄 (V&V)

- [x] 單元測試通過 (`npm test src/__tests__/calculators/gad-7.test.ts`)
- [x] 型別檢查通過 (`npx tsc --noEmit`)
- [x] Lint 通過 (`npm run lint`)
- [ ] E2E 測試通過（不適用 — 此為單元測試修正）

**新增/修改的測試（V&V 證據）：**
`src/__tests__/calculators/gad-7.test.ts` 的 `Config Structure` 測試擴充:
- 原: `expect(gad7Config.sections).toHaveLength(7)` ← 過時，會 fail
- 新: `expect(gad7Config.sections).toHaveLength(8)` + 兩個結構性檢查
  - 7 scored sections (至少一個 option value > 0)
  - 1 unscored section (id `gad7-q7`，所有 options value === 0)

更嚴格的測試，保留原本意圖（驗證有 7 個計分項）並把 Q8 functional impairment 也明確驗證。

跑 gad-7.test.ts 修前 4/5 pass → 修後 5/5 pass。

## 風險評估

**IEC 62304 安全性等級：**
- [x] Class A — 無傷害可能
- [ ] Class B — 非嚴重傷害
- [ ] Class C — 死亡或嚴重傷害

**TFDA 醫療器材分級：**
- [ ] 第一級
- [x] 第二級
- [ ] 第三級

**風險影響：**
無新增臨床風險 — 純測試 assertion 修正。實作未動，臨床評分演算法未動。改完反而提升測試覆蓋：新版會在「scored 數量改變」或「Q8 結構改變」時 fail，是更精確的回歸偵測。

**風險控制：**
N/A — 無新增風險。`npx jest gad-7.test.ts` 通過 5/5。

**ISO 14971 風險分析 Issue：**
N/A — 無新增風險。

## 關聯 Issues

- Refs #40 (test triage 第一案)

## 審查檢查清單

- [x] 程式碼符合專案命名慣例
- [x] 無硬編碼的 PHI 或敏感資訊
- [x] 使用 `escapeHTML()` 或 `textContent` 處理動態內容
- [x] 新增的 FHIR 查詢參數已使用 `encodeURIComponent()`
- [x] 計算器 ID 格式正確
- [ ] 中文翻譯已請臨床人員審閱（不適用 — 測試 assertion）