### PR TITLE
Fix kawasaki test: section id rename (kawasaki-extrem → kawasaki-extrem-acute)

### DIFF
--- a/src/__tests__/calculators/kawasaki.test.ts
+++ b/src/__tests__/calculators/kawasaki.test.ts
@@ -15,7 +15,7 @@ describe('Kawasaki Disease Calculator', () => {
     test('Criteria Not Met (No Fever)', () => {
         const result = calculateScoringResult(kawasakiConfig, {
             'kawasaki-fever': '0',
-            'kawasaki-extrem': '1',
+            'kawasaki-extrem-acute': '1',
             'kawasaki-exanthem': '1',
             'kawasaki-conjunctival': '1',
             'kawasaki-oral': '1',
@@ -52,7 +52,7 @@ describe('Kawasaki Disease Calculator', () => {
         // Fever (1) + 3 features (3) = 4
         const result = calculateScoringResult(kawasakiConfig, {
             'kawasaki-fever': '1',
-            'kawasaki-extrem': '1',
+            'kawasaki-extrem-acute': '1',
             'kawasaki-exanthem': '1',
             'kawasaki-conjunctival': '1'
         });
@@ -65,7 +65,7 @@ describe('Kawasaki Disease Calculator', () => {
         // Fever (1) + 4 features (4) = 5
         const result = calculateScoringResult(kawasakiConfig, {
             'kawasaki-fever': '1',
-            'kawasaki-extrem': '1',
+            'kawasaki-extrem-acute': '1',
             'kawasaki-exanthem': '1',
             'kawasaki-conjunctival': '1',
             'kawasaki-oral': '1'
@@ -82,7 +82,7 @@ describe('Kawasaki Disease Calculator', () => {
         // score 5 (should be Kawasaki by score, but renderer denies it)
         const outputNoFever = renderer(5, {
             'kawasaki-fever': 0,
-            'kawasaki-extrem': 1,
+            'kawasaki-extrem-acute': 1,
             'kawasaki-exanthem': 1,
             'kawasaki-conjunctival': 1,
             'kawasaki-oral': 1,
@@ -93,7 +93,7 @@ describe('Kawasaki Disease Calculator', () => {
         // Fever present, 4 features
         const outputClassic = renderer(5, {
             'kawasaki-fever': 1,
-            'kawasaki-extrem': 1,
+            'kawasaki-extrem-acute': 1,
             'kawasaki-exanthem': 1,
             'kawasaki-conjunctival': 1,
             'kawasaki-oral': 1
@@ -103,7 +103,7 @@ describe('Kawasaki Disease Calculator', () => {
         // Fever present, 2 features
         const outputIncomplete = renderer(3, {
             'kawasaki-fever': 1,
-            'kawasaki-extrem': 1,
+            'kawasaki-extrem-acute': 1,
             'kawasaki-exanthem': 1
         });
         expect(outputIncomplete).toContain('Consider Incomplete Kawasaki Disease');


### PR DESCRIPTION
## 變更說明

Refs #40。Test 2/16 — kawasaki 測試使用舊的 `kawasaki-extrem` id，實作已拆為 `kawasaki-extrem-acute` 與 `kawasaki-extrem-subacute`（依 Mayo 分類），導致測試每個 scenario 少 1 分。

**Stacked on PR #37。**

## Intended Use 影響評估

- [ ] **是**
- [x] **否** — 純測試 id rename，臨床演算法與實作未動

**說明：** 測試的 input section id 改名，calculator 實作未動。customResultRenderer 用 OR 邏輯吃 acute 或 subacute 任一，臨床語意完全不變。

## 影響範圍

- [x] 文件/測試

**受影響的 Calculator IDs：** kawasaki (測試 only)

**影響的其他模組/檔案：** `src/__tests__/calculators/kawasaki.test.ts`

## 測試紀錄 (V&V)

- [x] 單元測試通過 (`npx jest kawasaki.test.ts`) — 5/5
- [x] 型別檢查通過
- [x] Lint 通過

**V&V 證據：** kawasaki.test.ts 修前 3/5 fail (Criteria Not Met No Fever / Criteria Not Met <4 features / Kawasaki Disease Criteria Met) → 修後 5/5 pass。

## 風險評估

**IEC 62304:** Class A
**TFDA:** 第二級

**風險影響：** 無 — 純測試 id rename。

**風險控制：** N/A。

## 關聯 Issues

- Refs #40

## 審查檢查清單

- [x] 全部