### PR TITLE
Fix geneva-score test: update to standard Revised Geneva weighted score

### DIFF
--- a/src/__tests__/calculators/geneva-score.test.ts
+++ b/src/__tests__/calculators/geneva-score.test.ts
@@ -34,15 +34,13 @@ describe('Geneva Score Calculator', () => {
         expect(scoreItem!.interpretation).toBe('Low Risk');
     });
 
-    // Case 2: Intermediate Risk
-    // Age > 65 (1)
-    // HR 80 (1)
-    // Others 0
-    // Total 2
+    // Case 2: Intermediate Risk (standard Revised Geneva weighted score)
+    // Age > 65 (+1), HR 80 (75-94 → +3), others 0
+    // Total: 4 → Intermediate (4-10 range)
     test('Intermediate Risk Case', () => {
         const result = calculateGenevaScore({
             'geneva-age': '1',
-            'geneva-hr': '80', // 75-94 -> +1
+            'geneva-hr': '80',
             'geneva-prev-dvt': '0',
             'geneva-surgery': '0',
             'geneva-malignancy': '0',
@@ -54,24 +52,20 @@ describe('Geneva Score Calculator', () => {
         expect(result).not.toBeNull();
         const scoreItem = result!.find(r => r.label === 'Total Score');
         const score = parseInt(scoreItem!.value as string, 10);
-        expect(score).toBe(2);
+        expect(score).toBe(4);
         expect(scoreItem!.interpretation).toBe('Intermediate Risk');
     });
 
-    // Case 3: High Risk
-    // Age > 65 (1)
-    // Unilateral limb pain (1)
-    // Hemoptysis (1)
-    // Malignancy (1)
-    // HR 100 (+2)
-    // Total 6
+    // Case 3: High Risk (standard Revised Geneva weighted score)
+    // Age > 65 (+1), limb pain (+3), hemoptysis (+2), malignancy (+2), HR 100 (≥95 → +5)
+    // Total: 13 → High (≥11 range)
     test('High Risk Case', () => {
         const result = calculateGenevaScore({
             'geneva-age': '1',
-            'geneva-limb-pain': '1',
-            'geneva-hemoptysis': '1',
-            'geneva-malignancy': '1',
-            'geneva-hr': '100', // >=95 -> +2
+            'geneva-limb-pain': '3',
+            'geneva-hemoptysis': '2',
+            'geneva-malignancy': '2',
+            'geneva-hr': '100',
             'geneva-prev-dvt': '0',
             'geneva-surgery': '0',
             'geneva-palpation': '0'
@@ -80,7 +74,7 @@ describe('Geneva Score Calculator', () => {
         expect(result).not.toBeNull();
         const scoreItem = result!.find(r => r.label === 'Total Score');
         const score = parseInt(scoreItem!.value as string, 10);
-        expect(score).toBe(6);
+        expect(score).toBe(13);
         expect(scoreItem!.interpretation).toBe('High Risk');
     });
 


### PR DESCRIPTION
## 變更說明

Refs #40。Test 3/16 — geneva-score 從 simplified 改成 standard weighted，測試還用全部 +1 的舊 inputs/expected。

**Stacked on PR #37。**

## Intended Use 影響評估

- [ ] **是**
- [x] **否** — 純測試 input/expected 更新對齊已部署的 standard weighted 實作

**說明：** 實作早已從 simplified Geneva（1 點/項）改為 Revised Geneva 標準（權重 1-5），UI options 也已更新。測試 input value 與 expected score 仍停留在舊版，本 PR 把測試對齊現行實作。

## 影響範圍

- [x] 文件/測試

**受影響的 Calculator IDs：** geneva-score (測試 only)

**影響的其他模組/檔案：** `src/__tests__/calculators/geneva-score.test.ts`

## 測試紀錄 (V&V)

- [x] 單元測試通過 — geneva-score.test.ts 4/4
- [x] 型別檢查通過
- [x] Lint 通過

**V&V 證據:** 修前 Intermediate Risk Case 2/4、High Risk Case 6/9 fail → 修後 4/4 pass。

## 風險評估

**IEC 62304:** Class A
**TFDA:** 第二級

**風險影響：** 無 — 測試對齊實作，反而提升 V&V 真實覆蓋（修前測試是無效的，因為 input 跟 UI 不一致）。

**風險控制：** N/A。

## 關聯 Issues

- Refs #40

## 審查檢查清單

- [x] 全部