### PR TITLE
Fix gwtg-hf test: align expected scores with actual lookup tables

### DIFF
--- a/src/__tests__/calculators/gwtg-hf.test.ts
+++ b/src/__tests__/calculators/gwtg-hf.test.ts
@@ -11,15 +11,10 @@ describe('GWTG-HF Calculator', () => {
     // TC-001: Standard Calculation Tests
     // ===========================================
 
-    // Case 1: Low Risk
-    // SBP 150 (0)
-    // BUN 10 (0)
-    // Na 130 (0)
-    // Age 35 (0)
-    // HR 65 (0)
-    // COPD No (0)
-    // Race No (0)
-    // Total: 0 -> <1% mortality
+    // Case 1: Low Risk (score < 34 → "Low Risk", mortality '<1%' when ≤33)
+    // SBP 150 (9), BUN 10 (2), Na 130 (4), Age 35 (6), HR 65 (0),
+    // COPD No (0), Race No (0)
+    // Total: 21
     test('Low Risk Case', () => {
         const result = calculateGwtgHf({
             'gwtg-sbp': '150',
@@ -34,28 +29,23 @@ describe('GWTG-HF Calculator', () => {
         expect(result).not.toBeNull();
         const scoreItem = result!.find(r => r.label === 'GWTG-HF Score');
         const score = parseInt(scoreItem!.value as string, 10);
-        expect(score).toBe(0);
+        expect(score).toBe(21);
         const mortItem = result!.find(r => r.label === 'In-hospital Mortality');
         expect(mortItem!.value).toBe('<1%');
-        expect(scoreItem!.interpretation).toBe('Low Risk'); // actually default is Low Risk
+        expect(scoreItem!.interpretation).toBe('Low Risk');
     });
 
-    // Case 2: High Risk
-    // SBP 80 (28)
-    // BUN 80 (28)
-    // Na 145 (4)
-    // Age 85 (28)
-    // HR 120 (8)
-    // COPD Yes (2)
-    // Race No (0)
-    // Total: 28+28+4+28+8+2 = 98 -> >50% mortality
+    // Case 2: High Risk (score ≥75 → "High Risk", mortality '>50%' when ≥79)
+    // SBP 50 (28), BUN 150 (28), Na 130 (4), Age 100 (25), HR 150 (8),
+    // COPD Yes (2), Race No (0)
+    // Total: 28+28+4+25+8+2 = 95
     test('High Risk Case', () => {
         const result = calculateGwtgHf({
-            'gwtg-sbp': '80',
-            'gwtg-bun': '80',
-            'gwtg-sodium': '145',
-            'gwtg-age': '85',
-            'gwtg-hr': '120',
+            'gwtg-sbp': '50',
+            'gwtg-bun': '150',
+            'gwtg-sodium': '130',
+            'gwtg-age': '100',
+            'gwtg-hr': '150',
             copd: '2',
             race: '0'
         });
@@ -63,7 +53,7 @@ describe('GWTG-HF Calculator', () => {
         expect(result).not.toBeNull();
         const scoreItem = result!.find(r => r.label === 'GWTG-HF Score');
         const score = parseInt(scoreItem!.value as string, 10);
-        expect(score).toBe(98);
+        expect(score).toBe(95);
         const mortItem = result!.find(r => r.label === 'In-hospital Mortality');
         expect(mortItem!.value).toBe('>50%');
         expect(scoreItem!.interpretation).toBe('High Risk');


### PR DESCRIPTION
## 變更說明

Refs #40。Test 4/16 — gwtg-hf 用 fine-grained 查表評分（SBP/BUN/Na/Age/HR 各分段），測試的 inline 註解與 expected score 是用較簡單的舊評分計算的（如「SBP 150 (0)」但實際查表 = 9 點）。

**Stacked on PR #37。**

## Intended Use 影響評估

- [ ] **是**
- [x] **否** — 對齊現行查表演算法，未動實作

## 影響範圍

- [x] 文件/測試

**受影響的 Calculator IDs：** gwtg-hf (測試 only)

## 測試紀錄 (V&V)

- [x] gwtg-hf.test.ts 3/3 pass
- [x] tsc / lint 通過

**V&V 證據：** Low Risk Case: 0/21 fail → 21/21 pass；High Risk Case: 98/67 fail → 95/95 pass（換 inputs 真正落 High Risk band）。

## 風險評估

**IEC 62304:** Class A  **TFDA:** 第二級

**風險影響：** 無 — 測試對齊實作。新 inputs 更精確驗證 High Risk band（原 inputs 只達 Moderate）。

## 關聯 Issues

- Refs #40

## 審查檢查清單

- [x] 全部