### PR TITLE
Fix phenytoin-correction test: align with Winter-Tozer formula + 3.2 cutoff

### DIFF
--- a/src/__tests__/calculators/phenytoin-correction.test.ts
+++ b/src/__tests__/calculators/phenytoin-correction.test.ts
@@ -1,10 +1,14 @@
 import { phenytoinCorrectionCalculation } from '../../calculators/phenytoin-correction/calculation.js';
 
 describe('Phenytoin Correction Calculator', () => {
-    test('Should calculate for Normal Renal Function (K=0.1)', () => {
-        // Total 8.0, Albumin 3.0, K=0.1 (Normal)
-        // Denom = ((0.9) * 3.0 / 4.4) + 0.1 = (2.7 / 4.4) + 0.1 = 0.6136 + 0.1 = 0.7136
-        // Corrected = 8.0 / 0.7136 ≈ 11.21
+    // Winter-Tozer: corrected = total / (adj × albumin + 0.1)
+    // adj = 0.275 (normal renal), 0.2 (CrCl < 20 mL/min)
+    // Albumin > 3.2 g/dL: no correction needed (returns total as-is)
+
+    test('Should calculate for Normal Renal Function (adj=0.275, albumin 3.0)', () => {
+        // total 8.0, albumin 3.0 (≤3.2, formula applies), renal 'no' → adj 0.275
+        // denom = 0.275 × 3.0 + 0.1 = 0.925
+        // corrected = 8.0 / 0.925 = 8.65 → 8.6
         const result = phenytoinCorrectionCalculation({
             'pheny-total': 8.0,
             'pheny-albumin': 3.0,
@@ -12,15 +16,15 @@ describe('Phenytoin Correction Calculator', () => {
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].value).toBe(11.2);
-        expect(result[0].interpretation).toBe(''); // Within therapeutic range (10-20)
-        expect(result[0].alertClass).toBe('success');
+        expect(result[0].value).toBe(8.6);
+        expect(result[0].interpretation).toBe('Subtherapeutic');
+        expect(result[0].alertClass).toBe('info');
     });
 
-    test('Should calculate for Renal Failure (K=0.2)', () => {
-        // Total 8.0, Albumin 3.0, K=0.2 (Renal Failure)
-        // Denom = ((0.8) * 3.0 / 4.4) + 0.2 = (2.4 / 4.4) + 0.2 = 0.5454 + 0.2 = 0.7454
-        // Corrected = 8.0 / 0.7454 ≈ 10.73
+    test('Should calculate for Renal Failure (adj=0.2, albumin 3.0)', () => {
+        // total 8.0, albumin 3.0, renal 'yes' → adj 0.2
+        // denom = 0.2 × 3.0 + 0.1 = 0.7
+        // corrected = 8.0 / 0.7 = 11.43 → 11.4
         const result = phenytoinCorrectionCalculation({
             'pheny-total': 8.0,
             'pheny-albumin': 3.0,
@@ -28,38 +32,51 @@ describe('Phenytoin Correction Calculator', () => {
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].value).toBe(10.7);
-        expect(result[0].interpretation).toBe('');
+        expect(result[0].value).toBe(11.4);
+        expect(result[0].interpretation).toBe('Therapeutic');
     });
 
-    test('Should detect Subtherapeutic levels', () => {
-        // Total 5.0, Albumin 4.4, K=0.1 (Normal)
-        // Denom = ((0.9 * 4.4 / 4.4) + 0.1) = 0.9 + 0.1 = 1.0
-        // Corrected = 5.0 / 1.0 = 5.0
+    test('Should detect Subtherapeutic levels (formula applied)', () => {
+        // total 5.0, albumin 3.0, renal 'no'
+        // corrected = 5.0 / 0.925 = 5.41 → 5.4 (well below 10)
         const result = phenytoinCorrectionCalculation({
             'pheny-total': 5.0,
-            'pheny-albumin': 4.4,
+            'pheny-albumin': 3.0,
             'pheny-renal': 'no'
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].value).toBe(5.0);
+        expect(result[0].value).toBe(5.4);
         expect(result[0].interpretation).toBe('Subtherapeutic');
         expect(result[0].alertClass).toBe('info');
     });
 
-    test('Should detect Toxic levels', () => {
-        // Total 25.0, Albumin 4.4, K=0.1 -> Corrected = 25.0
+    test('Should detect Toxic levels (formula applied)', () => {
+        // total 25.0, albumin 3.0, renal 'no'
+        // corrected = 25.0 / 0.925 = 27.03 → 27.0 (>20)
         const result = phenytoinCorrectionCalculation({
             'pheny-total': 25.0,
-            'pheny-albumin': 4.4,
+            'pheny-albumin': 3.0,
             'pheny-renal': 'no'
         });
 
         expect(result).toHaveLength(1);
-        expect(result[0].value).toBe(25.0);
+        expect(result[0].value).toBe(27.0);
         expect(result[0].interpretation).toBe('Potentially Toxic');
         expect(result[0].alertClass).toBe('danger');
+    });
+
+    test('Should skip correction when albumin > 3.2 (No correction needed)', () => {
+        // albumin 4.4 > 3.2: returns measured total unchanged
+        const result = phenytoinCorrectionCalculation({
+            'pheny-total': 15.0,
+            'pheny-albumin': 4.4,
+            'pheny-renal': 'no'
+        });
+        expect(result).toHaveLength(1);
+        expect(result[0].value).toBe(15.0);
+        expect(result[0].interpretation).toBe('No correction needed');
+        expect(result[0].alertClass).toBe('info');
     });
 
     test('Should returned empty for missing inputs', () => {


### PR DESCRIPTION
## 變更說明

Refs #40。Test 6/16 — phenytoin 改用 Winter-Tozer 公式（adj 0.275/0.2）並加 albumin > 3.2 跳過 correction 分支，測試還用舊乘數 + 觸發 no-correction 的 albumin 4.4。

**Stacked on PR #37。**

## Intended Use 影響評估
- [x] **否** — 測試對齊現行 Winter-Tozer 實作

## 影響範圍
- [x] 文件/測試

## 測試紀錄 (V&V)
- [x] phenytoin-correction.test.ts 6/6 pass（含新增的 >3.2 no-correction 驗證）
- [x] tsc / lint 通過

**V&V 證據:** 修前 4/5 fail → 修後 6/6 pass。新增 No correction branch 測試，加強覆蓋。

## 風險評估
**IEC 62304:** Class A  **TFDA:** 第二級
**風險影響：** 無 — 測試對齊實作 + 新增 branch 測試。

## 關聯 Issues
Refs #40