### PR TITLE
Fix sodium-correction test: align with dual Katz/Hillier output

### DIFF
--- a/src/__tests__/calculators/sodium-correction.test.ts
+++ b/src/__tests__/calculators/sodium-correction.test.ts
@@ -4,83 +4,70 @@ import { calculateSodiumCorrection } from '../../calculators/sodium-correction/c
 
 describe('Sodium Correction Calculator', () => {
     describe('Calculation Logic', () => {
-        // formula: Na + Factor * ((Glucose - 100) / 100)
+        // The calculator returns BOTH reference corrections in a fixed order:
+        //   result[0] = Katz (1973), factor 1.6
+        //   result[1] = Hillier (1999), factor 2.4
+        // Formula: corrected = Na + factor × (glucose − 100) / 100
 
-        test('Standard Factor 1.6: Glucose 200', () => {
-            const input = {
+        test('Katz factor 1.6: Na 135, glucose 200', () => {
+            const result = calculateSodiumCorrection({
                 'measured-sodium': 135,
-                glucose: 200,
-                'correction-factor': '1.6'
-            };
-            const result = calculateSodiumCorrection(input);
+                glucose: 200
+            });
             expect(result).not.toBeNull();
-            if (result) {
-                // 135 + 1.6 * (100/100) = 136.6
-                expect(result[0].value).toBe('136.6');
-                expect(result[0].interpretation).toBe('Normal');
-            }
+            // 135 + 1.6 × (100/100) = 136.6
+            expect(result![0].label).toContain('Katz');
+            expect(result![0].value).toBe(136.6);
+            expect(result![0].interpretation).toBe('Normal');
         });
 
-        test('Standard Factor 1.6: Glucose 500', () => {
-            const input = {
+        test('Katz factor 1.6: Na 130, glucose 500', () => {
+            const result = calculateSodiumCorrection({
                 'measured-sodium': 130,
-                glucose: 500,
-                'correction-factor': '1.6'
-            };
-            const result = calculateSodiumCorrection(input);
+                glucose: 500
+            });
             expect(result).not.toBeNull();
-            if (result) {
-                // 130 + 1.6 * (400/100) = 130 + 6.4 = 136.4
-                expect(result[0].value).toBe('136.4');
-                expect(result[0].interpretation).toBe('Normal');
-            }
+            // 130 + 1.6 × (400/100) = 136.4
+            expect(result![0].value).toBe(136.4);
+            expect(result![0].interpretation).toBe('Normal');
         });
 
-        test('Katz Factor 2.4: Glucose 600', () => {
-            const input = {
+        test('Hillier factor 2.4: Na 125, glucose 600 (result[1])', () => {
+            const result = calculateSodiumCorrection({
                 'measured-sodium': 125,
-                glucose: 600,
-                'correction-factor': '2.4'
-            };
-            const result = calculateSodiumCorrection(input);
+                glucose: 600
+            });
             expect(result).not.toBeNull();
-            if (result) {
-                // 125 + 2.4 * (500/100) = 125 + 12 = 137.0
-                expect(result[0].value).toBe('137.0');
-                expect(result[0].interpretation).toBe('Normal');
-            }
+            // Hillier: 125 + 2.4 × (500/100) = 137
+            expect(result![1].label).toContain('Hillier');
+            expect(result![1].value).toBe(137);
+            expect(result![1].interpretation).toBe('Normal');
         });
 
-        test('Hyponatremia Result', () => {
-            const input = {
+        test('Hyponatremia (corrected < 136)', () => {
+            const result = calculateSodiumCorrection({
                 'measured-sodium': 120,
-                glucose: 200,
-                'correction-factor': '1.6'
-            };
-            const result = calculateSodiumCorrection(input);
-            // 120 + 1.6 = 121.6 -> Low
-            expect(result![0].interpretation).toBe('Low (Hyponatremia)');
+                glucose: 200
+            });
+            // Katz: 120 + 1.6 = 121.6 → Hyponatremia
+            expect(result![0].interpretation).toBe('Hyponatremia');
             expect(result![0].alertClass).toBe('warning');
         });
 
-        test('Hypernatremia Result', () => {
-            const input = {
+        test('Hypernatremia (corrected > 145)', () => {
+            const result = calculateSodiumCorrection({
                 'measured-sodium': 145,
-                glucose: 300,
-                'correction-factor': '1.6'
-            };
-            const result = calculateSodiumCorrection(input);
-            // 145 + 1.6 * 2 = 148.2 -> High
-            expect(result![0].interpretation).toBe('High (Hypernatremia)');
+                glucose: 300
+            });
+            // Katz: 145 + 1.6 × 2 = 148.2 → Hypernatremia
+            expect(result![0].interpretation).toBe('Hypernatremia');
             expect(result![0].alertClass).toBe('danger');
         });
 
         test('Missing inputs should return null', () => {
-            const input = {
+            const result = calculateSodiumCorrection({
                 'measured-sodium': 135
-                // missing glucose
-            };
-            const result = calculateSodiumCorrection(input as any);
+            } as any);
             expect(result).toBeNull();
         });
     });


### PR DESCRIPTION
## 變更說明

Refs #40。Test 7/16 — sodium-correction 改成同時回 Katz (1.6) + Hillier (2.4) 兩個 reference 公式（result[0] / result[1]），value 改回 number，interpretation 字串更新。

**Stacked on PR #37。**

## Intended Use 影響評估
- [x] **否** — 對齊已重設計的雙公式輸出實作

## 影響範圍
- [x] 文件/測試

## 測試紀錄 (V&V)
- [x] sodium-correction.test.ts 6/6 pass
- [x] tsc / lint 通過

## 風險評估
**IEC 62304:** Class A  **TFDA:** 第二級
**風險影響：** 無 — 測試對齊實作；新增「label 含 Katz/Hillier」assertion 提升覆蓋。

## 關聯 Issues
Refs #40