### PR TITLE
Fix free-water-deficit test: rename fwd-gender to fwd-sex + fwd-age-range

### DIFF
--- a/src/__tests__/calculators/free-water-deficit.test.ts
+++ b/src/__tests__/calculators/free-water-deficit.test.ts
@@ -6,68 +6,73 @@ describe('Free Water Deficit Calculator', () => {
         // Formula: TBW * (Na/140 - 1)
         // TBW = Weight * Factor
 
+        // Inputs: fwd-weight, fwd-sodium, fwd-sex (male/female), fwd-age-range
+        // (child/adult/elderly). fwd-desired-sodium defaults to 140.
+        // TBW factor: child 0.6, adult male 0.6, adult female 0.5,
+        //             elderly male 0.5, elderly female 0.45.
+
         test('Adult Male with Hypernatremia: Na 160', () => {
-            const input = {
+            const result = calculateFreeWaterDeficit({
                 'fwd-weight': 70,
                 'fwd-sodium': 160,
-                'fwd-gender': 'male'
-            };
-            const result = calculateFreeWaterDeficit(input);
+                'fwd-sex': 'male',
+                'fwd-age-range': 'adult'
+            });
             expect(result).not.toBeNull();
-            // TBW = 70 * 0.6 = 42L
-            // Deficit = 42 * (160/140 - 1) = 42 * 0.143 = 6.0L
-            if (result) {
-                const deficit = parseFloat(result[0].value as string);
-                expect(deficit).toBeCloseTo(6.0, 1);
-                expect(result[0].interpretation).toContain('Hypernatremia');
-            }
+            // TBW = 70 × 0.6 = 42L
+            // Deficit = 42 × (160/140 − 1) = 6.0L
+            const deficit = parseFloat(result![0].value as string);
+            expect(deficit).toBeCloseTo(6.0, 1);
+            expect(result![0].interpretation).toContain('Hypernatremia');
         });
 
         test('Adult Female with Hypernatremia: Na 155', () => {
-            const input = {
+            const result = calculateFreeWaterDeficit({
                 'fwd-weight': 60,
                 'fwd-sodium': 155,
-                'fwd-gender': 'female'
-            };
-            const result = calculateFreeWaterDeficit(input);
-            // TBW = 60 * 0.5 = 30L
-            // Deficit = 30 * (155/140 - 1) = 30 * 0.107 = 3.2L
+                'fwd-sex': 'female',
+                'fwd-age-range': 'adult'
+            });
+            // TBW = 60 × 0.5 = 30L
+            // Deficit = 30 × (155/140 − 1) = 3.2L
             const deficit = parseFloat(result![0].value as string);
             expect(deficit).toBeCloseTo(3.2, 1);
         });
 
         test('Elderly Female with Hypernatremia: Na 150', () => {
-            const input = {
+            const result = calculateFreeWaterDeficit({
                 'fwd-weight': 55,
                 'fwd-sodium': 150,
-                'fwd-gender': 'elderly_female'
-            };
-            const result = calculateFreeWaterDeficit(input);
-            // TBW = 55 * 0.45 = 24.75L
-            // Deficit = 24.75 * (150/140 - 1) = 24.75 * 0.0714 = 1.77L
+                'fwd-sex': 'female',
+                'fwd-age-range': 'elderly'
+            });
+            // TBW = 55 × 0.45 = 24.75L
+            // Deficit = 24.75 × (150/140 − 1) = 1.77L
             const deficit = parseFloat(result![0].value as string);
             expect(deficit).toBeCloseTo(1.8, 1);
         });
 
         test('Normal Sodium (Not Indicated): Na 140', () => {
-            const input = {
+            const result = calculateFreeWaterDeficit({
                 'fwd-weight': 70,
                 'fwd-sodium': 140,
-                'fwd-gender': 'male'
-            };
-            const result = calculateFreeWaterDeficit(input);
-            // Deficit = 42 * (140/140 - 1) = 0
+                'fwd-sex': 'male',
+                'fwd-age-range': 'adult'
+            });
+            // Deficit = 42 × (140/140 − 1) = 0
             const deficit = parseFloat(result![0].value as string);
             expect(deficit).toBe(0);
             expect(result![0].interpretation).toContain('Not Indicated');
         });
 
         test('Missing inputs should return null', () => {
-            const input = {
-                'fwd-weight': 70,
-                'fwd-sodium': 160
-            };
-            expect(calculateFreeWaterDeficit(input as any)).toBeNull();
+            expect(
+                calculateFreeWaterDeficit({
+                    'fwd-weight': 70,
+                    'fwd-sodium': 160
+                    // missing fwd-sex + fwd-age-range
+                } as any)
+            ).toBeNull();
         });
     });
 });


### PR DESCRIPTION
## 變更說明

Refs #40。Test 8/16 — free-water-deficit 把 `fwd-gender`（combined "elderly_female" 等）拆成 `fwd-sex` + `fwd-age-range`。測試用舊 key 導致 calc 永遠回 null。

**Stacked on PR #37。**

## Intended Use 影響評估
- [x] **否** — 純測試 input field 對齊已重構的 input schema

## 影響範圍
- [x] 文件/測試

## 測試紀錄 (V&V)
- [x] free-water-deficit.test.ts 5/5 pass
- [x] tsc / lint 通過

## 風險評估
**IEC 62304:** Class A  **TFDA:** 第二級
**風險影響：** 無 — 測試對齊實作 schema。

## 關聯 Issues
Refs #40