### PR TITLE
Fix errorHandler test: update user-facing strings to zh-TW localization

### DIFF
--- a/src/__tests__/errorHandler.test.ts
+++ b/src/__tests__/errorHandler.test.ts
@@ -296,9 +296,10 @@ describe('Error Handler Module', () => {
             const error = new FHIRDataError('FHIR connection lost');
             displayError(container, error);
 
+            // User-facing messages are localized to zh-TW (default project locale).
             const content = container.querySelector('.error-content')?.textContent?.trim();
             expect(content).toBe(
-                'Unable to retrieve patient data from EHR system. Please check connection or enter data manually.'
+                '無法從 EHR 系統取得病患資料。請檢查連線或手動輸入資料。'
             );
         });
 
@@ -307,7 +308,8 @@ describe('Error Handler Module', () => {
             displayError(container, error);
 
             const content = container.querySelector('.error-content')?.textContent?.trim();
-            expect(content).toBe('Input validation failed: Age must be positive');
+            // Localized prefix + original error message (preserved as-is)
+            expect(content).toBe('輸入驗證失敗：Age must be positive');
         });
 
         test('should use getUserFriendlyMessage for generic CalculatorError', () => {
@@ -323,8 +325,9 @@ describe('Error Handler Module', () => {
             displayError(container, error);
 
             const content = container.querySelector('.error-content')?.textContent?.trim();
+            // Generic fallback is also localized.
             expect(content).toBe(
-                'Calculator encountered an error. Please refresh the page and try again or contact support.'
+                '計算器發生錯誤。請重新整理頁面後再試，或聯繫技術支援。'
             );
         });
 


### PR DESCRIPTION
## 變更說明

Refs #40。Test 10/16 — errorHandler.ts 把 FHIR/ValidationError 前綴與 generic fallback 訊息中文化（zh-TW），測試還 assert 英文版字串導致 3 個 fail。

**Stacked on PR #37。**

## Intended Use 影響評估
- [x] **否** — 測試對齊已部署的 zh-TW 介面，未動實作

## 影響範圍
- [x] 文件/測試

## 測試紀錄 (V&V)
- [x] errorHandler.test.ts 36/36 pass（修前 33/36）

## 風險評估
**IEC 62304:** Class A  **TFDA:** 第二級
**風險影響：** 無 — 測試對齊實作。

## 關聯 Issues
Refs #40