### PR TITLE
Fix swipe-navigation test: mock review-gate isCalculatorApproved

### DIFF
--- a/src/__tests__/swipe-navigation.test.ts
+++ b/src/__tests__/swipe-navigation.test.ts
@@ -28,6 +28,13 @@ jest.mock('../calculators/index.js', () => ({
     getCalculatorMetadata: mockGetCalculatorMetadata
 }));
 
+// SwipeNavigation now filters the calculator list through isCalculatorApproved
+// (review gate). Tests need all three mock calculators to be treated as approved
+// so the swipe logic runs.
+jest.mock('../review-gate.js', () => ({
+    isCalculatorApproved: () => true
+}));
+
 import { initSwipeNavigation } from '../swipe-navigation.js';
 
 // Helper to create mock touch events


### PR DESCRIPTION
## 變更說明

Refs #40。Test 13/16 — swipe-navigation 改用 `isCalculatorApproved` 過濾 calculator 清單，但測試沒 mock review-gate 導致所有 calculator 被濾掉、listeners/indicators 都沒掛上。

**Stacked on PR #37。**

## Intended Use 影響評估
- [x] **否** — 純測試 mock 補完

## 影響範圍
- [x] 文件/測試

## 測試紀錄 (V&V)
- [x] swipe-navigation.test.ts 10/10 pass（修前 4/10）

## 風險評估
**IEC 62304:** Class A  **TFDA:** 第二級
**風險影響：** 無 — 補測試 mock。

## 關聯 Issues
Refs #40