### PR TITLE
Fix golden datasets for AF-Risk and FIB-4 after calculator consolidation

### DIFF
--- a/src/__tests__/golden-datasets/af-risk.json
+++ b/src/__tests__/golden-datasets/af-risk.json
@@ -1,13 +1,14 @@
 {
   "calculatorId": "af-risk",
   "calculatorName": "AF Stroke/Bleed Risk (CHA2DS2-VASc & HAS-BLED)",
-  "version": "1.0",
+  "version": "1.1",
   "calculatorType": "scoring",
+  "_notes": "v1.1: the unsupported aggregated 'Combined Risk' band was removed from the calculator (its CHA2DS2-VASc and HAS-BLED scores are interpreted separately per ESC/AHA guidelines and have no validated combined band). Golden cases now assert only the Total Score; per-axis interpretation is verified by the calculator's own unit tests.",
   "cases": [
     {
       "id": "GD-AFRISK-001",
-      "description": "Score 0 - low combined risk, young male, no risk factors",
-      "source": "Lip GY, et al. Chest. 2010;137(2):263-272. All 0 = Low Combined Risk.",
+      "description": "Score 0 - young male, no risk factors",
+      "source": "Lip GY, et al. Chest. 2010;137(2):263-272. All 0 input.",
       "inputs": {
         "chf": "0",
         "htn": "0",
@@ -28,13 +29,12 @@
         "hasbled-alcohol": "0"
       },
       "expected": [
-        { "label": "Total Score", "value": 0, "tolerance": 0 },
-        { "label": "Risk Level", "value": "Low Combined Risk" }
+        { "label": "Total Score", "value": 0, "tolerance": 0 }
       ]
     },
     {
       "id": "GD-AFRISK-002",
-      "description": "Score 2 - low combined risk, hypertension and diabetes only (CHA2DS2-VASc)",
+      "description": "Score 2 - hypertension and diabetes only (CHA2DS2-VASc)",
       "source": "Lip GY, et al. Chest. 2010. HTN (+1) + DM (+1) = 2.",
       "inputs": {
         "chf": "0",
@@ -56,13 +56,12 @@
         "hasbled-alcohol": "0"
       },
       "expected": [
-        { "label": "Total Score", "value": 2, "tolerance": 0 },
-        { "label": "Risk Level", "value": "Low Combined Risk" }
+        { "label": "Total Score", "value": 2, "tolerance": 0 }
       ]
     },
     {
       "id": "GD-AFRISK-003",
-      "description": "Score 5 - moderate combined risk, CHA2DS2-VASc factors + HAS-BLED factors",
+      "description": "Score 5 - CHA2DS2-VASc factors + HAS-BLED factors",
       "source": "Lip GY, et al. Age>=75 (+2) + Stroke (+2) + HAS-BLED elderly (+1) = 5.",
       "inputs": {
         "chf": "0",
@@ -84,14 +83,13 @@
         "hasbled-alcohol": "0"
       },
       "expected": [
-        { "label": "Total Score", "value": 5, "tolerance": 0 },
-        { "label": "Risk Level", "value": "Moderate Combined Risk" }
+        { "label": "Total Score", "value": 5, "tolerance": 0 }
       ]
     },
     {
       "id": "GD-AFRISK-004",
-      "description": "Score 8 - high combined risk, multiple CHA2DS2-VASc and HAS-BLED factors",
-      "source": "Combined: CHF (+1) + HTN (+1) + Age>=75 (+2) + Stroke (+2) + HAS-BLED HTN (+1) + HAS-BLED stroke (+1) = 8.",
+      "description": "Score 8 - multiple CHA2DS2-VASc and HAS-BLED factors",
+      "source": "CHF (+1) + HTN (+1) + Age>=75 (+2) + Stroke (+2) + HAS-BLED HTN (+1) + HAS-BLED stroke (+1) = 8.",
       "inputs": {
         "chf": "1",
         "htn": "1",
@@ -112,13 +110,12 @@
         "hasbled-alcohol": "0"
       },
       "expected": [
-        { "label": "Total Score", "value": 8, "tolerance": 0 },
-        { "label": "Risk Level", "value": "High Combined Risk" }
+        { "label": "Total Score", "value": 8, "tolerance": 0 }
       ]
     },
     {
       "id": "GD-AFRISK-005",
-      "description": "Score 12 - high combined risk, female with extensive comorbidities and bleeding risk",
+      "description": "Score 12 - female with extensive comorbidities and bleeding risk",
       "source": "CHF (+1) + HTN (+1) + Age>=75 (+2) + DM (+1) + Female (+1) + HAS-BLED HTN (+1) + HAS-BLED renal (+1) + HAS-BLED bleed (+1) + HAS-BLED elderly (+1) + HAS-BLED drugs (+1) + HAS-BLED alcohol (+1) = 12.",
       "inputs": {
         "chf": "1",
@@ -140,8 +137,7 @@
         "hasbled-alcohol": "1"
       },
       "expected": [
-        { "label": "Total Score", "value": 12, "tolerance": 0 },
-        { "label": "Risk Level", "value": "High Combined Risk" }
+        { "label": "Total Score", "value": 12, "tolerance": 0 }
       ]
     }
   ]

--- a/src/__tests__/golden-datasets/fib-4.json
+++ b/src/__tests__/golden-datasets/fib-4.json
@@ -1,8 +1,9 @@
 {
   "calculatorId": "fib-4",
   "calculatorName": "FIB-4 Fibrosis Index",
-  "version": "1.0",
+  "version": "1.1",
   "calculatorType": "simple",
+  "_notes": "v1.1: calculator was consolidated to return a single FIB-4 Score result item with the age-specific interpretation and Ishak stage embedded as fields on that item rather than as separate result entries. Golden cases assert the score numerically; the embedded interpretation/stage fields are exercised by the calculator's own unit tests (src/__tests__/calculators/fib-4.test.ts).",
   "cases": [
     {
       "id": "GD-FIB4-001",
@@ -20,14 +21,6 @@
           "value": 0.64,
           "unit": "points",
           "tolerance": 0.05
-        },
-        {
-          "label": "Age-Specific Interpretation",
-          "value": "Alternative fibrosis assessment"
-        },
-        {
-          "label": "Approximate Fibrosis Stage*",
-          "value": "Stage 0-1"
         }
       ]
     },
@@ -47,21 +40,13 @@
           "value": 1.69,
           "unit": "points",
           "tolerance": 0.05
-        },
-        {
-          "label": "Age-Specific Interpretation",
-          "value": "Further investigation"
-        },
-        {
-          "label": "Approximate Fibrosis Stage*",
-          "value": "Stage 2-3"
         }
       ]
     },
     {
       "id": "GD-FIB4-003",
       "description": "Indeterminate range",
-      "source": "FIB-4 = (60 * 55) / (150 * sqrt(40)) = 3300 / (150 * 6.325) = 3300 / 948.7 = 3.48 -- wait too high. Recalculate: 3300 / 948.7 = 3.48. That's high risk.",
+      "source": "FIB-4 = (55 * 45) / (180 * sqrt(40)) = 2475 / (180 * 6.324) = 2475 / 1138.4 = 2.17",
       "inputs": {
         "fib4-age": 55,
         "fib4-ast": 45,
@@ -74,14 +59,6 @@
           "value": 2.18,
           "unit": "points",
           "tolerance": 0.1
-        },
-        {
-          "label": "Age-Specific Interpretation",
-          "value": "Further investigation"
-        },
-        {
-          "label": "Approximate Fibrosis Stage*",
-          "value": "Stage 2-3"
         }
       ]
     },
@@ -101,14 +78,6 @@
           "value": 7.35,
           "unit": "points",
           "tolerance": 0.1
-        },
-        {
-          "label": "Age-Specific Interpretation",
-          "value": "Advanced fibrosis likely"
-        },
-        {
-          "label": "Approximate Fibrosis Stage*",
-          "value": "Stage 4-6"
         }
       ]
     },
@@ -128,14 +97,6 @@
           "value": 0.33,
           "unit": "points",
           "tolerance": 0.02
-        },
-        {
-          "label": "Age-Specific Interpretation",
-          "value": "Alternative fibrosis assessment"
-        },
-        {
-          "label": "Approximate Fibrosis Stage*",
-          "value": "Stage 0-1"
         }
       ]
     }


### PR DESCRIPTION
## 變更說明

Refs #40, refs #36。Test 16/16 — 最後一個。

兩個 golden datasets 過時:
1. **af-risk.json (v1.1)**: 移除 "Risk Level: Combined Risk" 期望（calculator 早已刪除該 dead band，commit `9f0f7d0`）
2. **fib-4.json (v1.1)**: 移除 "Age-Specific Interpretation" 與 "Approximate Fibrosis Stage" 期望（calculator 整併為單一 FIB-4 Score item，相關 metadata embed 在 item 內），並修正 GD-FIB4-003 source 註解 miscompute

兩者皆保留 Total Score / FIB-4 Score 的數值驗證，並加 `_notes` 欄位記錄 version bump 與理由。

**Stacked on PR #37。**

## Intended Use 影響評估
- [x] **否** — golden dataset 對齊 calculator 已部署的 result schema

## 影響範圍
- [x] 文件/測試

## 測試紀錄 (V&V)
- [x] golden-dataset.test.ts 416/416 pass（修前 406/416）

## 風險評估
**IEC 62304:** Class A  **TFDA:** 第二級
**風險影響：** 無 — 移除已不存在的欄位期望；數值驗證維持完整。被移除欄位的覆蓋仍由各 calculator 的 unit test 提供。

## 關聯 Issues
Refs #40 (closes the test triage), Refs #36 (depends on Combined Risk removal)

## 審查檢查清單
- [x] 全部