### PR TITLE
Fix e2e/tests/07 import: setupAuthenticated → setupAuthenticatedContext

### DIFF
--- a/e2e/tests/07-accessibility.spec.ts
+++ b/e2e/tests/07-accessibility.spec.ts
@@ -4,11 +4,11 @@
  */
 import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
-import { setupAuthenticated } from '../helpers/auth-bypass';
+import { setupAuthenticatedContext } from '../helpers/auth-bypass';
 
 test.describe('Accessibility Audit', () => {
     test('index page has no WCAG 2.1 AA violations', async ({ page }) => {
-        await setupAuthenticated(page);
+        await setupAuthenticatedContext(page);
         await page.goto('/');
         await page.waitForSelector('#calculator-list');
 
@@ -20,7 +20,7 @@ test.describe('Accessibility Audit', () => {
     });
 
     test('calculator page has no WCAG 2.1 AA violations', async ({ page }) => {
-        await setupAuthenticated(page);
+        await setupAuthenticatedContext(page);
         await page.goto('/calculator.html?name=bmi-bsa');
         await page.waitForSelector('#calculator-container');
 
@@ -32,7 +32,7 @@ test.describe('Accessibility Audit', () => {
     });
 
     test('skip link is visible on focus', async ({ page }) => {
-        await setupAuthenticated(page);
+        await setupAuthenticatedContext(page);
         await page.goto('/');
 
         // Tab to focus the skip link
@@ -43,7 +43,7 @@ test.describe('Accessibility Audit', () => {
     });
 
     test('landmark structure is correct on index page', async ({ page }) => {
-        await setupAuthenticated(page);
+        await setupAuthenticatedContext(page);
         await page.goto('/');
 
         // Check header landmark


### PR DESCRIPTION
## 變更說明

Closes #58。5 行 typo 修正 — `07-accessibility.spec.ts` import `setupAuthenticated` 但 `auth-bypass.ts` export 的是 `setupAuthenticatedContext`，導致整個 firefox e2e job 在 module load 時崩潰、連帶取消 chromium/webkit。問題在所有近期 main commit 都存在。

## Intended Use 影響評估

- [ ] **是** — 此變更影響預期用途、臨床判讀邏輯或結果呈現
- [x] **否** — 不影響預期用途（純內部重構、文件、CI、樣式等）

**說明：**
1 個 import 改名 + 4 個 call site 對齊。E2E 測試本身的斷言邏輯未動，無 production code 變更。

## 影響範圍

- [ ] 計算器邏輯
- [ ] 使用者介面
- [ ] FHIR 資料整合
- [ ] 安全性相關
- [ ] 基礎架構/CI
- [x] 文件/測試

**受影響的 Calculator IDs：**
- N/A — 不影響任何 calculator

**影響的其他模組/檔案：**
- `e2e/tests/07-accessibility.spec.ts` — 1 個 import + 4 個 call site rename

## 測試紀錄 (V&V)

- [x] 單元測試通過 (`npm test`)（不影響）
- [x] 型別檢查通過 (`npx tsc --noEmit`)
- [x] Lint 通過
- [ ] E2E 測試通過 — 待 CI 驗證

**新增/修改的測試（V&V 證據）：**
N/A — 測試 import 名稱對齊已存在的 export。Spec 的斷言邏輯與覆蓋範圍未動。

## 風險評估

**IEC 62304 安全性等級：**
- [x] Class A — 無傷害可能
- [ ] Class B
- [ ] Class C

**TFDA 醫療器材分級：**
- [ ] 第一級
- [x] 第二級
- [ ] 第三級

**風險影響：**
無新增臨床風險。修正後恢復 e2e accessibility 測試覆蓋（之前完全 fail），反而提升 V&V 嚴密度。

**風險控制：**
N/A — 無新增風險。

**ISO 14971 風險分析 Issue：**
N/A — 無新增風險。

## 關聯 Issues
Closes #58

## 審查檢查清單
- [x] 程式碼符合專案命名慣例
- [x] 無硬編碼的 PHI 或敏感資訊
- [x] 使用 `escapeHTML()` 或 `textContent` 處理動態內容
- [x] 新增的 FHIR 查詢參數已使用 `encodeURIComponent()`
- [x] 計算器 ID 格式正確
- [ ] 中文翻譯已請臨床人員審閱（不適用）