### PR TITLE
Promote 3 ESLint 10 rules back to error after fixing 4 violations

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -150,13 +150,9 @@ export default [
             // read. Project has accumulated 140+ pre-existing instances;
             // demoting to warning keeps the lint signal without blocking CI.
             'no-useless-assignment': 'warn',
-            // The following are new-in-ESLint-10 rules that flag pre-existing
-            // patterns in the codebase. Demoted to warnings to keep the
-            // migration PR's scope to "flat config only"; targeted source
-            // fixes can land separately.
-            'preserve-caught-error': 'warn',
-            'no-unreachable': 'warn',
-            'constructor-super': 'warn',
+            // Stricter ESLint 10 / 'recommended' rules — kept as errors now
+            // that the pre-existing violations in the codebase have been
+            // fixed (see commits referencing #57's follow-up).
             // null-checks via `== null` / `!= null` are an idiomatic
             // TS/JS pattern (covers both null and undefined in one op).
             eqeqeq: ['error', 'always', { null: 'ignore' }],

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -12,10 +12,10 @@ describe('Utility Functions', () => {
             // @ts-ignore
             global.Date = class extends Date {
                 constructor(date: any) {
-                    if (date) {
-                        return super(date) as any;
-                    }
-                    return mockToday as any;
+                    // Always call super() exactly once (derived-class
+                    // constructor contract); fall back to the mocked default
+                    // when no argument is supplied.
+                    super(date ?? mockToday);
                 }
                 static now() {
                     return mockToday.getTime();

--- a/src/calculators/index.ts
+++ b/src/calculators/index.ts
@@ -257,7 +257,11 @@ export async function loadCalculator(calculatorId: string): Promise<CalculatorMo
 
         return (calculator as CalculatorModule) || (Object.values(module)[0] as CalculatorModule);
     } catch (error) {
-        throw new Error(`Unable to load calculator module: ${calculatorId}`);
+        // `Error(msg, { cause })` is ES2022 and tsconfig targets ES2020; use
+        // property assignment to attach the cause for `preserve-caught-error`.
+        const wrapped = new Error(`Unable to load calculator module: ${calculatorId}`);
+        (wrapped as Error & { cause?: unknown }).cause = error;
+        throw wrapped;
     }
 }
 

--- a/src/calculators/nafld-fibrosis-score/index.ts
+++ b/src/calculators/nafld-fibrosis-score/index.ts
@@ -130,13 +130,11 @@ const config: FormulaCalculatorConfig = {
         const items = results
             .map(r => {
                 if (r.label === 'Interpretation' && r.alertPayload) {
+                    // Render Interpretation as a separate alert block rather
+                    // than a redundant result-item row (calculation.ts emits
+                    // both Item 0 "NAFLD Score" with interpretation=stage and
+                    // Item 1 "Interpretation" with the full message).
                     alertHtml = uiBuilder.createAlert(r.alertPayload);
-                    return ''; // Don't show redundant item, or show it? original showed both result item (stage) AND alert.
-                    // Original: Result Item (Interpretation: stage), then Alert (Interpretation: message).
-                    // In calculation.ts:
-                    // Item 0: Label: NAFLD Score, Interp: stage.
-                    // Item 1: Label: Interpretation, Value: full message.
-                    // Let's filter out Interpretation item for display as item, and just use it for the Alert HTML block.
                     return '';
                 }
 

--- a/src/lazyLoader.ts
+++ b/src/lazyLoader.ts
@@ -76,7 +76,11 @@ export async function loadCalculator(calculatorId: string): Promise<unknown> {
 
         return module;
     } catch (error) {
-        throw new Error(`Calculator "${calculatorId}" not found`);
+        // `Error(msg, { cause })` is ES2022 and tsconfig targets ES2020; use
+        // property assignment to attach the cause for `preserve-caught-error`.
+        const wrapped = new Error(`Calculator "${calculatorId}" not found`);
+        (wrapped as Error & { cause?: unknown }).cause = error;
+        throw wrapped;
     }
 }
 


### PR DESCRIPTION
## 變更說明

Refs PR #60 (ESLint 10 flat-config migration)。修 4 個 PR #60 暫降為 warning 的規則的 pre-existing violations，並把 3 個規則升回 error 嚴格度。

修正:
1. `src/__tests__/utils.test.ts:16` (`constructor-super`) — mock Date constructor 修為 always-call-super 模式
2. `src/calculators/index.ts:260` (`preserve-caught-error`) — re-throw 加 cause 屬性
3. `src/lazyLoader.ts:79` (`preserve-caught-error`) — 同上
4. `src/calculators/nafld-fibrosis-score/index.ts:140` (`no-unreachable`) — 移除重複的 `return ''`

`no-useless-assignment` (140 instances) 暫保留為 warning（PR #60 既有 scope，獨立處理）。

## Intended Use 影響評估

- [ ] **是** — 此變更影響預期用途、臨床判讀邏輯或結果呈現
- [x] **否** — 不影響預期用途（純內部重構、文件、CI、樣式等）

**說明：**
- `constructor-super` 修正讓 mock Date constructor 符合 derived-class 規範（原寫法是 runtime bug 但 TS `as any` 隱藏；測試行為一致）
- `preserve-caught-error` 修正附加 cause 屬性，提升錯誤追蹤資訊但不改變 throw 訊息或時機
- `no-unreachable` 修正刪除完全不可達的死碼，runtime 行為等同

Calculator 邏輯、UI、FHIR、安全規則均未動。

## 影響範圍

- [ ] 計算器邏輯
- [ ] 使用者介面
- [ ] FHIR 資料整合
- [x] 安全性相關（錯誤追蹤資訊更完整）
- [x] 基礎架構/CI
- [x] 文件/測試

**受影響的 Calculator IDs：**
- nafld-fibrosis-score（純死碼移除，runtime 邏輯不變）

**影響的其他模組/檔案：**
- `eslint.config.js` — 3 個規則從 warn 升 error
- `src/__tests__/utils.test.ts` — Date mock constructor 修正
- `src/calculators/index.ts` — loadCalculator catch handler 加 cause
- `src/lazyLoader.ts` — 同上
- `src/calculators/nafld-fibrosis-score/index.ts` — 移除 unreachable 死碼

## 測試紀錄 (V&V)

- [x] 單元測試通過 (`npm test`) — 121 suites / **3662 tests pass**
- [x] 型別檢查通過 (`npx tsc --noEmit`)
- [x] Lint 通過 (`npm run lint`) — **0 errors** / 933 warnings
- [ ] E2E 測試通過 — 不適用（純 lint 規則升級 + 對應修正）

**新增/修改的測試（V&V 證據）：**
N/A — 全部修正皆為 runtime 行為等同的小修正:
- utils.test.ts mock Date：修前 ESLint 抓的是真實 runtime bug（derived class 沒 super() 會炸），TS `as any` 之前掩蓋；修後行為一致
- catch handler：修前 cause 資訊遺失，修後保留錯誤 trace
- nafld unreachable：純刪除死碼

各檔 3662/3662 tests 通過驗證無 regression。

## 風險評估

**IEC 62304 安全性等級：**
- [x] Class A — 無傷害可能
- [ ] Class B
- [ ] Class C

**TFDA 醫療器材分級：**
- [ ] 第一級
- [x] 第二級
- [ ] 第三級

**風險影響：**
- **正面**: ESLint 規則嚴格化能更早抓到未來新增的類似 bug；catch handler 保留 cause 提升 production trace 品質
- **無新增臨床風險**: runtime 行為等同

**風險控制：**
- Lint + tsc + 3662 tests 三道 gate 通過
- 改動皆為最小化（property 賦值 vs `Error(msg, { cause })` ES2022 構造形式，配合既有 ES2020 target）

**ISO 14971 風險分析 Issue：**
N/A — 無新增風險。

## 關聯 Issues
Refs PR #60

## 審查檢查清單
- [x] 程式碼符合專案命名慣例
- [x] 無硬編碼的 PHI 或敏感資訊
- [x] 使用 `escapeHTML()` 或 `textContent` 處理動態內容
- [x] 新增的 FHIR 查詢參數已使用 `encodeURIComponent()`
- [x] 計算器 ID 格式正確
- [ ] 中文翻譯已請臨床人員審閱（不適用）