### PR TITLE
Fix e2e firefox NS_ERROR via vite preview + fail-fast=false matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,7 @@ jobs:
         needs: [build-and-test]
 
         strategy:
+            fail-fast: false
             matrix:
                 browser: [chromium, firefox, webkit]
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -32,8 +32,14 @@ export default defineConfig({
     ],
 
     webServer: {
-        command: 'npx http-server -p 8000 -c-1',
+        // Use `vite preview` (serves `dist/`) rather than `http-server`.
+        // http-server's HTTP/1.1 keep-alive handling causes
+        // NS_ERROR_NET_EMPTY_RESPONSE on Firefox + Playwright on CI runners;
+        // vite preview is the Playwright-recommended dev server and is
+        // closer to what the production Nginx container serves.
+        command: 'npx vite preview --port 8000 --strictPort',
         port: 8000,
         reuseExistingServer: !process.env.CI,
+        timeout: 60000,
     },
 });


### PR DESCRIPTION
## 變更說明

Refs #69。修 e2e firefox NS_ERROR_NET_EMPTY_RESPONSE 的兩個面向:

1. **playwright.config.ts**: 把 webServer 從 `http-server` 換成 `vite preview`。http-server 的 HTTP/1.1 keep-alive 處理在 GitHub Actions ubuntu runner 上會觸發 firefox 端 NS_ERROR_NET_EMPTY_RESPONSE。Vite preview 是 Playwright 上游推薦的 dev server，已是專案依賴，且serve `dist/` 與 production Nginx serve 內容一致。
2. **ci.yml**: e2e matrix 加 `fail-fast: false`。原本 firefox fail 會直接 cancel chromium 跟 webkit，導致 review 看不到後兩者實際狀態。

## Intended Use 影響評估

- [ ] **是** — 此變更影響預期用途、臨床判讀邏輯或結果呈現
- [x] **否** — 不影響預期用途（純內部重構、文件、CI、樣式等）

**說明：**
純 e2e 測試基礎設施配置變更。Production runtime / Nginx serve 配置 / calculator 邏輯 / UI / FHIR / 安全規則均未動。

## 影響範圍

- [ ] 計算器邏輯
- [ ] 使用者介面
- [ ] FHIR 資料整合
- [ ] 安全性相關
- [x] 基礎架構/CI
- [ ] 文件/測試

**受影響的 Calculator IDs：**
- N/A — 無 calculator 變更

**影響的其他模組/檔案：**
- `playwright.config.ts` — webServer command
- `.github/workflows/ci.yml` — e2e matrix fail-fast

## 測試紀錄 (V&V)

- [x] 單元測試通過 (`npm test`) — 不影響
- [x] 型別檢查通過
- [x] Lint 通過
- [ ] E2E 測試通過 — 待 CI 驗證（本 PR 即驗證 firefox NS_ERROR 是否解掉）

**新增/修改的測試（V&V 證據）：**
N/A — 純 e2e 基礎設施配置。將透過此 PR 的 CI 結果直接驗證:
- 修前 firefox: NS_ERROR_NET_EMPTY_RESPONSE 一律失敗（chromium/webkit 被連帶 cancel）
- 修後預期:
  - vite preview 在 firefox 上行為正確 → e2e firefox 至少能跑到 spec 的斷言層
  - fail-fast=false 讓 chromium/webkit 即使 firefox 失敗也能完成跑完

## 風險評估

**IEC 62304 安全性等級：**
- [x] Class A — 無傷害可能
- [ ] Class B
- [ ] Class C

**TFDA 醫療器材分級：**
- [ ] 第一級
- [x] 第二級
- [ ] 第三級

**風險影響：**
- **正面**: 恢復 firefox 端 e2e 覆蓋；fail-fast=false 提供更完整的 browser-by-browser 信號
- **無新增臨床風險**: 不動 production code
- **殘餘**: vite preview 的 SPA fallback 行為可能與 http-server 略異；若 e2e 有相對路徑依賴 http-server 行為的隱含假設，需個別調整（會在 PR CI 結果顯現）

**風險控制：**
- 透過此 PR 的 CI 結果即時驗證
- 若 vite preview 引入新問題，可 revert 此 PR；http-server 是上一個已知狀態

**ISO 14971 風險分析 Issue：**
N/A — 無新增臨床風險。

## 關聯 Issues
Refs #69

## 審查檢查清單
- [x] 程式碼符合專案命名慣例
- [x] 無硬編碼的 PHI 或敏感資訊
- [x] 使用 `escapeHTML()` 或 `textContent` 處理動態內容
- [x] 新增的 FHIR 查詢參數已使用 `encodeURIComponent()`
- [x] 計算器 ID 格式正確
- [ ] 中文翻譯已請臨床人員審閱（不適用）

---

## ⚠️ 更新: PR scope 與後續

本 PR 解決了 issue #69 描述的 `NS_ERROR_NET_EMPTY_RESPONSE` — 所有 3 個 browser (chromium / firefox / webkit) 都不再因 http-server 連線問題而失敗於 module load 階段。

**但 vite preview 暴露了 pre-existing e2e 測試期望 drift**（i18n 預設 zh-TW、calculator 數量 84 vs expected 90、FHIR mock storage shape）—  獨立追蹤於 #72，不在本 PR scope 內。

也就是說:
- #69 本身已 **完全解決**（NS_ERROR 不再出現）
- e2e CI 仍紅，但失敗原因從「server connection」變為「test expectation drift」
- main 上 e2e 從一直紅（不同失敗）變成另一種紅，**沒有 net regression**
- chromium / webkit 因 fail-fast=false 終於可以獨立執行，提供新 debug 資訊